### PR TITLE
Make the probe walk on the planet and not teleport

### DIFF
--- a/src/main/java/br/com/elo7/starlink/domains/planet/dto/PlanetDTO.java
+++ b/src/main/java/br/com/elo7/starlink/domains/planet/dto/PlanetDTO.java
@@ -2,6 +2,7 @@ package br.com.elo7.starlink.domains.planet.dto;
 
 import br.com.elo7.starlink.exception.ApplicationException;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.http.HttpStatus;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -32,7 +33,7 @@ public class PlanetDTO {
                 y > this.getHeight() ||
                 y < 0;
         if (invalid) {
-            throw new ApplicationException("Object is off planet");
+            throw new ApplicationException("Object is off planet", HttpStatus.BAD_REQUEST);
         }
         return this;
     }
@@ -40,7 +41,7 @@ public class PlanetDTO {
     public PlanetDTO thereIsNoObjectAtCoordinates(int x, int y) {
         for (ObjectDTO object : this.getObjects()) {
             if (y == object.getY() && x == object.getX()) {
-                throw new ApplicationException("There is already an object in this area");
+                throw new ApplicationException("There is already an object in this area", HttpStatus.BAD_REQUEST);
             }
         }
         return this;

--- a/src/main/java/br/com/elo7/starlink/domains/probe/service/ProbeService.java
+++ b/src/main/java/br/com/elo7/starlink/domains/probe/service/ProbeService.java
@@ -11,6 +11,6 @@ public interface ProbeService {
     ProbeDTO find(Long id);
     void save(ProbeDTO planetDTO);
     void sendCommand(Long probeId, CommandDTO commandDTO);
-    void moveProbe(ProbeDTO probe, String commands);
+    void moveProbe(ProbeDTO probe, char command);
     void sendToPlanet(Long probeId, AreaDTO area);
 }

--- a/src/test/java/br/com/elo7/starlink/e2e/E2eTest.java
+++ b/src/test/java/br/com/elo7/starlink/e2e/E2eTest.java
@@ -1,5 +1,9 @@
 package br.com.elo7.starlink.e2e;
 
+import br.com.elo7.starlink.domains.planet.dto.PlanetDTO;
+import br.com.elo7.starlink.domains.probe.dto.CommandDTO;
+import br.com.elo7.starlink.domains.probe.dto.ProbeDTO;
+import br.com.elo7.starlink.domains.user.dto.UserDTO;
 import com.google.gson.Gson;
 import org.jeasy.random.EasyRandom;
 import org.junit.jupiter.api.BeforeEach;
@@ -7,11 +11,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import static br.com.elo7.starlink.domains.probe.enumeration.Direction.N;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class E2eTest {
 
     protected final EasyRandom generator = new EasyRandom();
@@ -35,23 +43,69 @@ public class E2eTest {
     public void should_execute_main_flow_success() throws Exception {
         var expectedX = 1;
         var expectedY = 3;
-        var initialX = 1;
-        var initialY = 2;
-        var planetWidth = 5;
-        var planetHeight = 5;
-        var command = "LMLMLMLMM";
+
+        var probe = generator.nextObject(ProbeDTO.class);
+        probe.setId(1L);
+        probe.setX(1);
+        probe.setY(2);
+
+        var planet = generator.nextObject(PlanetDTO.class);
+        planet.setId(1L);
+        planet.setHeight(5);
+        planet.setWidth(5);
+
+        var command = generator.nextObject(CommandDTO.class);
+        command.setCommands("LMLMLMLMM");
+        command.setPlanetId(planet.getId());
+        command.setDirection(N);
+
+        var user = generator.nextObject(UserDTO.class);
 
         new MainFlow(mockMvc, generator, gson)
-                .createAUser()
-                .doLoginWithThisUserAndSaveToken()
-                .shouldFindAUserWithThisTokenAndExistsOneUser()
-                .thenCreateAPlanetWithThisSize(planetWidth, planetHeight)
-                .shouldFindThisPlanet()
-                .thenCreateAProbe()
-                .sendThisProbeToThisPlanetWithThisCoordinates(initialX, initialY)
-                .shouldFindThisPlanetWithOneObjectAndTheseCoordinates(initialX, initialY)
-                .sendACommandToThisProbe(command)
-                .thisProbeShouldBeWithTheseCoordinates(expectedX, expectedY)
-                .theObjectInThisPlanetShouldBeWithTheseCoordinates(expectedX, expectedY);
+                .createAUser(user)
+                .doLoginWithThisUserAndSaveToken(user)
+                .thenCreateAPlanet(planet)
+                .shouldFindThisPlanet(planet)
+                .thenCreateAProbe(probe)
+                .sendThisProbeToThisPlanet(probe, planet)
+                .shouldFindThisPlanetWithOneObjectAndTheseCoordinates(planet, probe)
+                .sendThisCommandToThisProbe(command, probe.getId())
+                .thisProbeShouldBeWithTheseCoordinates(probe.getId(), expectedX, expectedY)
+                .theObjectInThisPlanetShouldBeWithTheseCoordinates(planet.getId(), expectedX, expectedY);
+    }
+
+    @Test
+    public void should_execute_main_flow_with_another_probe_on_way_error() throws Exception {
+        var firstProbe = generator.nextObject(ProbeDTO.class);
+        firstProbe.setId(1L);
+        firstProbe.setX(0);
+        firstProbe.setY(0);
+
+        var secondProbe = generator.nextObject(ProbeDTO.class);
+        secondProbe.setId(2L);
+        secondProbe.setX(2);
+        secondProbe.setY(1);
+
+        var planet = generator.nextObject(PlanetDTO.class);
+        planet.setId(1L);
+        planet.setHeight(5);
+        planet.setWidth(5);
+
+        var command = generator.nextObject(CommandDTO.class);
+        command.setCommands("MRMMM");
+        command.setPlanetId(planet.getId());
+        command.setDirection(N);
+
+        var user = generator.nextObject(UserDTO.class);
+
+        new MainFlow(mockMvc, generator, gson)
+                .createAUser(user)
+                .doLoginWithThisUserAndSaveToken(user)
+                .thenCreateAPlanet(planet)
+                .thenCreateAProbe(firstProbe)
+                .thenCreateAProbe(secondProbe)
+                .sendThisProbeToThisPlanet(firstProbe, planet)
+                .sendThisProbeToThisPlanet(secondProbe, planet)
+                .sendACommandToThisProbeAndReturnBadRequest(command, firstProbe.getId());
     }
 }


### PR DESCRIPTION
On current scenario when one probe move with another probe in way, the application allows. This commit does an implementation that does not allow this behavior.

Resolves: https://github.com/HenryFarias/elo7-starlink/issues/4